### PR TITLE
add responsive IFRAME

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -8,3 +8,19 @@
     margin: 0 auto;
     display: block;
 }
+
+.iframe-container {
+  overflow: hidden;
+  padding-top: 56.25%;
+  position: relative;
+  margin-bottom: 10px;
+}
+
+.iframe-container iframe {
+   border: 0;
+   height: 100%;
+   left: 0;
+   position: absolute;
+   top: 0;
+   width: 100%;
+}

--- a/index.md
+++ b/index.md
@@ -35,7 +35,9 @@ If the receiving device can validate the token, the connection will be allowed, 
 
 Here a quick demo:
 
-<iframe width="640" height="480" src="/assets/videos/SYNwall_site_demo.webm" frameborder="0"> </iframe>
+<div class="iframe-container">
+  <iframe src="/assets/videos/SYNwall_site_demo.webm"> </iframe>
+</div>
 
 # How you can install it
 


### PR DESCRIPTION
I couldn't see the embedded video because the iframe was too small for my video resolution.
I've modified it to fit the page width (as-is and with responsive iframe):
![pre-post](https://user-images.githubusercontent.com/5462153/80221653-e4efaf00-8645-11ea-9f22-25a62ae59563.jpg)
